### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/iceberginfra/faef3906-df8e-474c-840a-26f5e5157fd8/d91277ab-7f54-486a-925a-69987f9a096f/_apis/work/boardbadge/9c1dc845-06a3-4921-a086-22fd5c9a21dc)](https://dev.azure.com/iceberginfra/faef3906-df8e-474c-840a-26f5e5157fd8/_boards/board/t/d91277ab-7f54-486a-925a-69987f9a096f/Microsoft.RequirementCategory)
 # react-tic-tac-toe


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/iceberginfra/faef3906-df8e-474c-840a-26f5e5157fd8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.